### PR TITLE
Added ApexSense Dev Mode.app + zsh script to install required software to run the app from the source 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,20 @@ jobs:
           path: out/make/ApexSense.dmg
           compression-level: 0
 
+      - name: Create ApexSense Dev Mode Platypus app
+        run: platypus -a "ApexSense Dev Mode" -o 'Text Window' -i ./assets/icons/icon.icns -u "Daniel Kulas" -V "1.0.0" -I com.kulas.ApexSense.devmode -y -l ./setup.zsh ./packaging/ApexSense\ Dev\ Mode.app
+
+      - name: Sign ApexSense Dev Mode.app
+        env:
+          MAC_SIGNING_IDENTITY: ${{ secrets.MAC_SIGNING_IDENTITY }}
+        run: codesign --sign $MAC_SIGNING_IDENTITY --verbose --force --timestamp ./packaging/ApexSense\ Dev\ Mode.app
+        
+      - name: Upload ApexSense Dev Mode.app Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ApexSense Dev Mode.app
+          path: ./packaging/ApexSense\ Dev\ Mode.app
+
   build-windows-x64:
     runs-on: [self-hosted, Windows, X64]
     steps:
@@ -108,7 +122,6 @@ jobs:
           path: out/make/squirrel.windows/x64/ApexSenseSetup.exe
           compression-level: 0
 
-        
   create-release:
     needs: ['build-macOS-ARM64', 'build-windows-x64']
     runs-on: [self-hosted, macOS, ARM64]
@@ -118,6 +131,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ApexSense-macOS-ARM64.dmg
+
+      - name: Download ApexSense Dev Mode.app Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ApexSense Dev Mode.app
 
       - name: Download Windows Artifact
         uses: actions/download-artifact@v4
@@ -140,6 +158,16 @@ jobs:
           upload_url: ${{ steps.create-release-step.outputs.upload_url }}
           asset_path: ${{ github.workspace }}/ApexSense.dmg
           asset_name: ApexSense-macOS-ARM64.dmg
+          asset_content_type: application/octet-stream
+
+      - name: Upload ApexSense Dev Mode Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release-step.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/ApexSense\ Dev\ Mode.app
+          asset_name: ApexSense Dev Mode.app
           asset_content_type: application/octet-stream
 
       - name: Upload Windows Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Sign ApexSense Dev Mode.app
         env:
           MAC_SIGNING_IDENTITY: ${{ secrets.MAC_SIGNING_IDENTITY }}
-        run: codesign --sign $MAC_SIGNING_IDENTITY --verbose --force --timestamp ./packaging/ApexSense\ Dev\ Mode.app
+        run: codesign --sign "$MAC_SIGNING_IDENTITY" --verbose --force --timestamp ./packaging/ApexSense\ Dev\ Mode.app
         
       - name: Upload ApexSense Dev Mode.app Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -52,6 +52,20 @@ jobs:
           path: out/make/ApexSense.dmg
           compression-level: 0
 
+      - name: Create ApexSense Dev Mode Platypus app
+        run: platypus -a "ApexSense Dev Mode" -o 'Text Window' -i ./assets/icons/icon.icns -u "Daniel Kulas" -V "1.0.0" -I com.kulas.ApexSense.devmode -y -l ./setup.zsh ./packaging/ApexSense\ Dev\ Mode.app
+
+      - name: Sign ApexSense Dev Mode.app
+        env:
+          MAC_SIGNING_IDENTITY: ${{ secrets.MAC_SIGNING_IDENTITY }}
+        run: codesign --sign $MAC_SIGNING_IDENTITY --verbose --force --timestamp ./packaging/ApexSense\ Dev\ Mode.app
+        
+      - name: Upload ApexSense Dev Mode.app Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ApexSense Dev Mode.app
+          path: ./packaging/ApexSense\ Dev\ Mode.app
+
   build-and-upload-windows:
     runs-on: [self-hosted, Windows, X64]
 

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Sign ApexSense Dev Mode.app
         env:
           MAC_SIGNING_IDENTITY: ${{ secrets.MAC_SIGNING_IDENTITY }}
-        run: codesign --sign $MAC_SIGNING_IDENTITY --verbose --force --timestamp ./packaging/ApexSense\ Dev\ Mode.app
+        run: codesign --sign "$MAC_SIGNING_IDENTITY" --verbose --force --timestamp ./packaging/ApexSense\ Dev\ Mode.app
         
       - name: Upload ApexSense Dev Mode.app Artifact
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apexsense",
   "productName": "ApexSense",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Visualize G-forces recorded by Garmin Catalyst",
   "main": "src/electron/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apexsense",
   "productName": "ApexSense",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Visualize G-forces recorded by Garmin Catalyst",
   "main": "src/electron/main.js",
   "scripts": {

--- a/setup.zsh
+++ b/setup.zsh
@@ -7,24 +7,14 @@
 #   Someone on my youtube video commented that they have an Intel Macbook and cannot use the pre-built Apple Silicon macOS binary
 #   I suggested to follow the readme on how to setup up their system to run from he source code but they were not well-versed 
 #   in terminal commands. This is an attempt at streamlining that process.
+#   Platypus is used to to package up the script into an .app bundle
 
 apexsense_version="1.0.1"
 
-echo "🏎️  ApexSense ${apexsense_version} development environment quick setup.\n"
+apexsense_output=$HOME/ApexSense-${apexsense_version}
 
-xcode-select -p &>/dev/null
-if [ $? -ne 0 ]; then
-    echo ""
-    echo "⚠️ Xcode command line tools are not installed ⚠️"
-    echo ""
-    echo "A window will appear asking to install these tools."
-    echo "These tools are required to run ApexSense from the source code."
-    echo "Click on Install, accept Apple's license agreement, and run ApexSense Setup again after installation completes."
-    xcode-select --install
-    echo "You can click on the 'Quit' button to dismiss this message." 
-else 
-    apexsense_output=$HOME/ApexSense-${apexsense_version}
-
+###### Functions ######
+launch_apexsense_if_ready() {
     if [ -f "${apexsense_output}/package.json" ]; then
         echo "Launching ApexSense from the source code..."
         cd ${apexsense_output}
@@ -32,53 +22,114 @@ else
         npm start
         exit 0
     fi
+}
 
-    echo "ApexSense source files will be saved in ${apexsense_output}\n\n"
+check_for_xcode_cli_tools() {
+    xcode-select -p &>/dev/null
+    if [ $? -ne 0 ]; then
+        echo ""
+        echo "⚠️ Xcode command line tools are not installed ⚠️"
+        echo ""
+        $(xcode-select --install) &
+        echo ""
+        echo "A window will appear asking to install these tools."
+        echo "These tools are required to run ApexSense from the source code."
+        echo ""
+        echo "Click on Install, accept Apple's license agreement, then wait for the software to download and install."
+        echo ""
+        echo "Keep this window open while the Xcode command line tools are downloading..."
+        echo ""
+        echo "When the download completes, click on 'Done' in the Xcode command line tools installer window to continue." 
 
-    # Python setup
-    # `xcode-select --install` will install a valid instance of python
-    # Invoking python3 before installing the xcode cli tools will trigger 
-    # a UI prompt to inform the end-user to install them
-    py_version=$(python3 --version)
-    if [[ $py_version == *"No developer tools"* ]]; then
-        echo "Ensure you have Xcode Command Line Tools installed"
-        xcode-select --install
-        exit -1
-    else
-        echo "Found $(python3 --version)."
-        numpy_installed=false
-        opencv_installed=false
+        sleep 5
 
-        if python3 -c "import numpy" 2>/dev/null; then numpy_installed=true; fi
-        if python3 -c "import cv2" 2>/dev/null; then opencv_installed=true; fi
-
-        if ! $numpy_installed || ! $opencv_installed; then
-            echo "Installing numpy, opencv-python..."
-            pip3 install numpy opencv-python --quiet &>/dev/null
-        fi
+        local installer_proc_name="Install Command Line Developer Tool"
+        while pgrep -f "${installer_proc_name}" > /dev/null; do
+            sleep 3
+        done
     fi
 
-    # Node.js install
+    if ! [ -d "/Library/Developer/CommandLineTools" ]; then
+        echo "The Xcode command line developer tools did not appear to install correctly."
+        echo "Exiting..."
+        exit -1
+    fi
+}
+
+setup_python() {
+    # `xcode-select --install` will install a valid instance of python
+    py_version=$(python3 --version)
+    if [[ $py_version == *"No developer tools"* ]]; then
+        echo "Ensure you have Xcode Command Line Tools installed."
+        exit -1
+    fi
+
+    echo "Found $(python3 --version)."
+
+    numpy_installed=false
+    opencv_installed=false
+    if python3 -c "import numpy" 2>/dev/null; then numpy_installed=true; fi
+    if python3 -c "import cv2" 2>/dev/null; then opencv_installed=true; fi
+
+    if ! $numpy_installed || ! $opencv_installed; then
+        echo "Installing numpy, opencv-python..."
+        pip3 install numpy opencv-python --quiet &>/dev/null
+    fi
+}
+
+install_nvm_node() { 
     if ! command -v npm; then
-        echo "Installing Node.js"
+        echo "Installing Node.js..."
         touch ~/.zshrc
         curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh &>/dev/null | bash &>/dev/null
         source ~/.zshrc
         nvm install node &>/dev/null
     fi
+}
 
-    # ApexSense source code setup
+download_apexsense() {
     apexsense_zip_output=/tmp/ApexSense-${apexsense_version}.zip
-    echo "Downloading ApexSense v${apexsense_version} source code to ${apexsense_zip_output}"
-    curl -L "https://github.com/shaboinkin90/ApexSense/archive/refs/tags/v${apexsense_version}.zip" -o ${apexsense_zip_output} &>/dev/null
-    unzip -q ${apexsense_zip_output} -d $HOME
-    rm ${apexsense_zip_output}
+    src_url="https://github.com/shaboinkin90/ApexSense/archive/refs/tags/v${apexsense_version}.zip" 
+    echo "Downloading ApexSense v${apexsense_version} source code from ${src_url}"
+    curl -L $src_url -o $apexsense_zip_output &>/dev/null
+    unzip -q $apexsense_zip_output -d $HOME
+    rm $apexsense_zip_output
+}
 
+prepare_and_launch_apexsense() {
     echo "Downloading dependencies for ApexSense..."
     cd ${apexsense_output}
     npm install &>/dev/null
 
+    if ! [ -d $apexsense_output/node_modules ]; then
+        # On testing in a virtual machine, sometimes the download would fail. Running again "works"
+        npm install &>/dev/null
+    fi
     npm start
+}
 
-    echo "Setup Complete ✅"
-fi
+###### Start #######
+
+launch_apexsense_if_ready # will exit
+
+echo "\n🏎️  ApexSense ${apexsense_version} development environment quick setup.\n"
+
+check_for_xcode_cli_tools # can exit
+
+echo "ApexSense source files will be saved in ${apexsense_output}"
+
+echo "1️⃣"
+setup_python # can exit
+
+echo "2️⃣"
+install_nvm_node
+
+echo "3️⃣"
+download_apexsense
+
+echo "4️⃣"
+prepare_and_launch_apexsense
+
+echo "Setup Complete ✅"
+echo ""
+echo "Run ApexSense Dev Mode.app again to launch ApexSense."

--- a/setup.zsh
+++ b/setup.zsh
@@ -1,0 +1,84 @@
+#!/bin/zsh
+
+# Shell script for setting up required libraries to run ApexSense from the source code
+# This was written for macOS in mind
+#
+# Reason for this script: 
+#   Someone on my youtube video commented that they have an Intel Macbook and cannot use the pre-built Apple Silicon macOS binary
+#   I suggested to follow the readme on how to setup up their system to run from he source code but they were not well-versed 
+#   in terminal commands. This is an attempt at streamlining that process.
+
+apexsense_version="1.0.1"
+
+echo "🏎️  ApexSense ${apexsense_version} development environment quick setup.\n"
+
+xcode-select -p &>/dev/null
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "⚠️ Xcode command line tools are not installed ⚠️"
+    echo ""
+    echo "A window will appear asking to install these tools."
+    echo "These tools are required to run ApexSense from the source code."
+    echo "Click on Install, accept Apple's license agreement, and run ApexSense Setup again after installation completes."
+    xcode-select --install
+    echo "You can click on the 'Quit' button to dismiss this message." 
+else 
+    apexsense_output=$HOME/ApexSense-${apexsense_version}
+
+    if [ -f "${apexsense_output}/package.json" ]; then
+        echo "Launching ApexSense from the source code..."
+        cd ${apexsense_output}
+        source ~/.zshrc
+        npm start
+        exit 0
+    fi
+
+    echo "ApexSense source files will be saved in ${apexsense_output}\n\n"
+
+    # Python setup
+    # `xcode-select --install` will install a valid instance of python
+    # Invoking python3 before installing the xcode cli tools will trigger 
+    # a UI prompt to inform the end-user to install them
+    py_version=$(python3 --version)
+    if [[ $py_version == *"No developer tools"* ]]; then
+        echo "Ensure you have Xcode Command Line Tools installed"
+        xcode-select --install
+        exit -1
+    else
+        echo "Found $(python3 --version)."
+        numpy_installed=false
+        opencv_installed=false
+
+        if python3 -c "import numpy" 2>/dev/null; then numpy_installed=true; fi
+        if python3 -c "import cv2" 2>/dev/null; then opencv_installed=true; fi
+
+        if ! $numpy_installed || ! $opencv_installed; then
+            echo "Installing numpy, opencv-python..."
+            pip3 install numpy opencv-python --quiet &>/dev/null
+        fi
+    fi
+
+    # Node.js install
+    if ! command -v npm; then
+        echo "Installing Node.js"
+        touch ~/.zshrc
+        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh &>/dev/null | bash &>/dev/null
+        source ~/.zshrc
+        nvm install node &>/dev/null
+    fi
+
+    # ApexSense source code setup
+    apexsense_zip_output=/tmp/ApexSense-${apexsense_version}.zip
+    echo "Downloading ApexSense v${apexsense_version} source code to ${apexsense_zip_output}"
+    curl -L "https://github.com/shaboinkin90/ApexSense/archive/refs/tags/v${apexsense_version}.zip" -o ${apexsense_zip_output} &>/dev/null
+    unzip -q ${apexsense_zip_output} -d $HOME
+    rm ${apexsense_zip_output}
+
+    echo "Downloading dependencies for ApexSense..."
+    cd ${apexsense_output}
+    npm install &>/dev/null
+
+    npm start
+
+    echo "Setup Complete ✅"
+fi

--- a/setup.zsh
+++ b/setup.zsh
@@ -9,15 +9,45 @@
 #   in terminal commands. This is an attempt at streamlining that process.
 #   Platypus is used to to package up the script into an .app bundle
 
-apexsense_version="1.0.1"
 
-apexsense_output=$HOME/ApexSense-${apexsense_version}
+
+
+# Extract the tag_name from the JSON response, which is the version number
+
+apexsense_version=""
+apexsense_output=""
 
 ###### Functions ######
+get_latest_apexsense_version() {
+    github_releases_url="https://api.github.com/repos/shaboinkin90/ApexSense/releases/latest"
+    latest_release_json=$(curl -s "$github_releases_url")
+    local curl_exit_status=$?
+    if [[ $curl_exit_status -ne 0 ]]; then
+        echo "‼️ Failed to query ${github_releases_url}. ‼️" >&2
+        echo "Check your network connection or check if you can access the ApexSense repository on Github at https://github.com/shaboinkin90/ApexSense/releases/" >&2
+        echo "Exiting..." >&2
+        exit 1
+    fi
+
+    latest_version=$(echo "${latest_release_json}" | grep '"tag_name":' | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
+    echo "$latest_version"
+}
+
 launch_apexsense_if_ready() {
-    if [ -f "${apexsense_output}/package.json" ]; then
+    if [[ -z "$apexsense_output" ]]; then
+        # problem getting the version number, maybe due to network issue querying github, see if a copy exists
+        apexsense_output=$(find "${HOME}" -type d -name 'ApexSense-v*' | sort -V | tail -n 1)
+        if [[ -z "$apexsense_output" ]]; then
+            echo "Could not determine the latest version of ApexSense to download nor did it find an existing copy of ApexSense."
+            echo "Check your network connection or check if you can access the ApexSense repository on Github at https://github.com/shaboinkin90/ApexSense/releases/"
+            echo "Exiting..."
+            exit 1
+        fi
+    fi
+
+    if [[ -f "${apexsense_output}/package.json" ]]; then
         echo "Launching ApexSense from the source code..."
-        cd ${apexsense_output}
+        cd "$apexsense_output"
         source ~/.zshrc
         npm start
         exit 0
@@ -26,22 +56,20 @@ launch_apexsense_if_ready() {
 
 check_for_xcode_cli_tools() {
     xcode-select -p &>/dev/null
-    if [ $? -ne 0 ]; then
+    if [[ $? -ne 0 ]]; then
         echo ""
         echo "⚠️ Xcode command line tools are not installed ⚠️"
         echo ""
-        $(xcode-select --install) &
+        xcode-select --install
         echo ""
         echo "A window will appear asking to install these tools."
         echo "These tools are required to run ApexSense from the source code."
         echo ""
         echo "Click on Install, accept Apple's license agreement, then wait for the software to download and install."
         echo ""
-        echo "Keep this window open while the Xcode command line tools are downloading..."
+        echo "Keep this window open while the Xcode command line tools finish installing..."
         echo ""
-        echo "When the download completes, click on 'Done' in the Xcode command line tools installer window to continue." 
-
-        sleep 5
+        echo "When the installation completes, click on 'Done' in the Xcode command line tools installer window to continue." 
 
         local installer_proc_name="Install Command Line Developer Tool"
         while pgrep -f "${installer_proc_name}" > /dev/null; do
@@ -49,29 +77,29 @@ check_for_xcode_cli_tools() {
         done
     fi
 
-    if ! [ -d "/Library/Developer/CommandLineTools" ]; then
-        echo "The Xcode command line developer tools did not appear to install correctly."
-        echo "Exiting..."
-        exit -1
+    if [[ !  -d "/Library/Developer/CommandLineTools" ]]; then
+        echo "The Xcode command line developer tools did not appear to install correctly." >&2
+        echo "Exiting..." >&2
+        exit 1
     fi
 }
 
 setup_python() {
     # `xcode-select --install` will install a valid instance of python
-    py_version=$(python3 --version)
+    local py_version=$(python3 --version)
     if [[ $py_version == *"No developer tools"* ]]; then
         echo "Ensure you have Xcode Command Line Tools installed."
-        exit -1
+        exit 1
     fi
 
-    echo "Found $(python3 --version)."
+    echo "Found $py_version."
 
-    numpy_installed=false
-    opencv_installed=false
-    if python3 -c "import numpy" 2>/dev/null; then numpy_installed=true; fi
-    if python3 -c "import cv2" 2>/dev/null; then opencv_installed=true; fi
+    local numpy_installed="false"
+    local opencv_installed="false"
+    if python3 -c "import numpy" 2>/dev/null; then numpy_installed="true"; fi
+    if python3 -c "import cv2" 2>/dev/null; then opencv_installed="true"; fi
 
-    if ! $numpy_installed || ! $opencv_installed; then
+    if [[ $numpy_installed != "true" ]] || [[ $opencv_installed != "true" ]]; then
         echo "Installing numpy, opencv-python..."
         pip3 install numpy opencv-python --quiet &>/dev/null
     fi
@@ -81,55 +109,89 @@ install_nvm_node() {
     if ! command -v npm; then
         echo "Installing Node.js..."
         touch ~/.zshrc
-        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh &>/dev/null | bash &>/dev/null
+        curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh" &>/dev/null | bash &>/dev/null
         source ~/.zshrc
         nvm install node &>/dev/null
     fi
 }
 
 download_apexsense() {
-    apexsense_zip_output=/tmp/ApexSense-${apexsense_version}.zip
-    src_url="https://github.com/shaboinkin90/ApexSense/archive/refs/tags/v${apexsense_version}.zip" 
-    echo "Downloading ApexSense v${apexsense_version} source code from ${src_url}"
-    curl -L $src_url -o $apexsense_zip_output &>/dev/null
-    unzip -q $apexsense_zip_output -d $HOME
-    rm $apexsense_zip_output
+    local temp_zip_output=$(mktemp -d)
+    if [[ ! -d "$temp_zip_output" ]]; then 
+        echo "Failed to create a temporary directory to store the zip." >&2
+        echo "Exiting..."
+        exit 1
+    fi
+    
+    local apexsense_zip_output="${temp_zip_output}/ApexSense-${apexsense_version}.zip"
+    local src_url="https://github.com/shaboinkin90/ApexSense/archive/refs/tags/${apexsense_version}.zip" 
+    
+    echo "Downloading ApexSense ${apexsense_version} source code from ${src_url}"
+    curl -L "$src_url" -o "$apexsense_zip_output" &>/dev/null
+    local curl_exit_status=$?
+    if [[ $curl_exit_status -ne 0 ]]; then
+        echo "‼️ Failed to download from ${src_url}. ‼️"
+        echo "Check your network connection or check if you can access the ApexSense repository on Github at ${src_url}" >&2
+        echo "Exiting..." >&2
+        exit 1
+    fi
+
+    local temp_zip_extract=$(mktemp -d)
+    if [[ ! -d "$temp_zip_extract" ]]; then 
+        echo "Failed to create a temporary directory to extract the zip." >&2
+        echo "Exiting..."
+        exit 1
+    fi
+
+    unzip -q "$apexsense_zip_output" -d "$temp_zip_extract"
+    mv "${temp_zip_extract}"/* "$apexsense_output"
+    trap "rm -rf ${temp_zip_output} ${temp_zip_extract}" EXIT
 }
 
 prepare_and_launch_apexsense() {
-    echo "Downloading dependencies for ApexSense..."
-    cd ${apexsense_output}
+    echo "Downloading dependencies for ApexSense...this might take a few minutes..."
+    cd $apexsense_output
     npm install &>/dev/null
 
-    if ! [ -d $apexsense_output/node_modules ]; then
+    if [[ ! -d "${apexsense_output}/node_modules" ]]; then
         # On testing in a virtual machine, sometimes the download would fail. Running again "works"
         npm install &>/dev/null
     fi
-    npm start
 }
 
 ###### Start #######
 
-launch_apexsense_if_ready # will exit
+
+apexsense_version=$(get_latest_apexsense_version)
+if [[ $apexsense_version =~ v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    apexsense_output=$HOME/ApexSense-${apexsense_version}
+fi
+
+launch_apexsense_if_ready
+
 
 echo "\n🏎️  ApexSense ${apexsense_version} development environment quick setup.\n"
 
 check_for_xcode_cli_tools # can exit
 
-echo "ApexSense source files will be saved in ${apexsense_output}"
+echo "\n🟣 ApexSense source files will be saved in ${apexsense_output} 🟣"
 
-echo "1️⃣"
+echo "🔵⚪️⚪️⚪️" 
 setup_python # can exit
 
-echo "2️⃣"
+echo "🟢🔵⚪️⚪️"
 install_nvm_node
 
-echo "3️⃣"
+echo "🟢🟢🔵⚪️"
 download_apexsense
 
-echo "4️⃣"
+echo "🟢🟢🟢🔵"
 prepare_and_launch_apexsense
 
-echo "Setup Complete ✅"
+echo "🟢🟢🟢🟢"
+echo "Setup Complete"
+
+npm start
+
 echo ""
 echo "Run ApexSense Dev Mode.app again to launch ApexSense."


### PR DESCRIPTION
I don't have an Intel Mac to generate a binary for. Instructing others to run it from the source themselves is problematic if there is unfamiliarity with using a terminal.

A zsh script is made to allow for a 1 shot setup + running of the app through an .app bundle generated by Platypus.

Platypus is used during the build steps to take the setup.zsh file and create the app bundle. It will be uploaded to releases along with the .dmg and .exe for the packaged app.

This is only intended to be used on macOS, though the script can be easily modified to run on Linux if desired. 